### PR TITLE
bug fix in GoalTask

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ curl -sSL http://get.gazebosim.org | sh
 ```
 If you already have a gazebo in your system, please make sure its version is greater than 9.6. You can check gazebo version by running `gazebo --version`. SocialRobot had been tested with Gazebo 9.6 and Gazebo 10.0.
 
-You might need to add the model path in this repp to GAZEBO_MODEL_PATH:
+You might need to add the model path in this repo to GAZEBO_MODEL_PATH:
 ```bash
 export GAZEBO_MODEL_PATH=REPO_ROOT/python/social_bot/models:$GAZEBO_MODEL_PATH
 ```

--- a/python/social_bot/teacher_tasks.py
+++ b/python/social_bot/teacher_tasks.py
@@ -51,6 +51,7 @@ class GoalTask(teacher.Task):
                 it's considered a failure and is given reward -1
             random_range (float): the goal's random position range
         """
+        super().__init__()
         self._goal_name = goal_name
         self._success_distance_thresh = success_distance_thresh
         self._fail_distance_thresh = fail_distance_thresh
@@ -62,7 +63,7 @@ class GoalTask(teacher.Task):
         """
         Start a teaching episode for this task.
         Args:
-            agent (pygazebo.Agent): the learning agent 
+            agent (pygazebo.Agent): the learning agent
             world (pygazebo.World): the simulation world
         """
         agent_sentence = yield


### PR DESCRIPTION
Need to call the superclass's constructor in GoalTask in order to inherit the variables defined in the superclass, e.g., reward_weight.