### PR TITLE
reset speed to 0 after resetting target

### DIFF
--- a/pygazebo/pygazebo.cc
+++ b/pygazebo/pygazebo.cc
@@ -135,6 +135,9 @@ class Model {
         std::make_tuple(lin_ver.X(), lin_ver.Y(), lin_ver.Z()),
         std::make_tuple(ang_ver.X(), ang_ver.Y(), ang_ver.Z()));
   }
+  void Reset() {
+    model_->ResetPhysicsStates();
+  }
 };
 
 class Agent : public Model {
@@ -570,7 +573,10 @@ PYBIND11_MODULE(pygazebo, m) {
            &Model::GetVelocities,
            "Get ((Linear velocity x, Linear velocity y, Linear velocity z),"
            "(Angular velocity x, Angular velocity y, Angular velocity z))"
-           "of the model");
+           "of the model")
+      .def("reset",
+           &Model::Reset,
+           "Resets the pose and velocities of the model");
 
   py::class_<JointState>(m, "JointState")
       .def(py::init<unsigned int>())

--- a/python/social_bot/teacher_tasks.py
+++ b/python/social_bot/teacher_tasks.py
@@ -113,6 +113,7 @@ class GoalTask(teacher.Task):
             self._initial_dist = np.linalg.norm(loc - agent_loc)
             if self._initial_dist > self._success_distance_thresh:
                 break
+        goal.reset()
         goal.set_pose((loc, (0, 0, 0)))
 
     def get_goal_name(self):


### PR DESCRIPTION
Currently the ball is sometimes rolling after reset.  It seems this change makes the ball less likely to roll after reset.
Maybe rolling can still happen if ball is initialized to be overlapping with another object in the grocery ground.

After pulling this change, folks will need to do the following to get grocery_ground working:

```
cd SocialRobot_REPO_ROOT
cd build
cmake ..
make -j```

if ```cmake ..``` complains about cannot find configuration file provided by "gazebo", run
```sudo apt install libgazebo9-dev``` where the version number 9 comes from ```gazebo --version```
