### PR TITLE
Performance improving of pr2 gripping task

### DIFF
--- a/examples/sac_pr2.gin
+++ b/examples/sac_pr2.gin
@@ -1,0 +1,27 @@
+# DISPLAY=null python -m alf.bin.train --root_dir=~/tmp/pr2_sac --gin_file=sac_pr2.gin
+
+include 'common_nonimage_sac.gin'
+import social_bot
+
+# environment config
+create_environment.env_name="SocialBot-Pr2Gripper-v0"
+create_environment.num_parallel_environments=12
+create_environment.env_load_fn=@suite_socialbot.load
+# suite_socialbot.load.gym_env_wrappers=(@FrameStack,)
+
+# algorithm config
+actor/Adam.learning_rate=5e-4
+critic/Adam.learning_rate=5e-4
+alpha/Adam.learning_rate=5e-4
+
+# training config
+TrainerConfig.initial_collect_steps=1000
+TrainerConfig.mini_batch_length=2
+TrainerConfig.unroll_length=1
+TrainerConfig.mini_batch_size=512
+TrainerConfig.summary_interval=100
+TrainerConfig.eval_interval=500
+TrainerConfig.checkpoint_interval=500
+TrainerConfig.num_updates_per_train_step=1
+
+TFUniformReplayBuffer.max_length=100000

--- a/python/social_bot/envs/gazebo_base.py
+++ b/python/social_bot/envs/gazebo_base.py
@@ -291,10 +291,11 @@ def _xpath_modify_xml(xml, modifications):
 
         # set text value
         for ele in tree.xpath(key):
-            logging.debug("Set value: %s %s", key, value)
             if len(value) != 0:
+                logging.debug("Set value: %s %s", key, value)
                 ele.text = value
             else:
+                logging.debug("Removing: %s", key)
                 ele.getparent().remove(ele)
 
     xml = etree.tostring(tree, encoding='unicode')

--- a/python/social_bot/envs/gazebo_base.py
+++ b/python/social_bot/envs/gazebo_base.py
@@ -204,7 +204,8 @@ def _xpath_modify_xml(xml, modifications):
           </camera>
     </sensor>
 
-    1. set element value: ${selector}=${value}
+    1. set element value: ${selector}=${value}, if ${value} is empty,
+    the element will be removed
     "//image/width=128"
     "//image/height=128"
     "//image/format=L8"
@@ -291,7 +292,10 @@ def _xpath_modify_xml(xml, modifications):
         # set text value
         for ele in tree.xpath(key):
             logging.debug("Set value: %s %s", key, value)
-            ele.text = value
+            if len(value) != 0:
+                ele.text = value
+            else:
+                ele.getparent().remove(ele)
 
     xml = etree.tostring(tree, encoding='unicode')
     logging.debug(xml)

--- a/python/social_bot/envs/pr2.py
+++ b/python/social_bot/envs/pr2.py
@@ -24,8 +24,16 @@ PR2_WORLD_SETTING = [
     # "//sensor[contains(@name, 'wide_stereo_gazebo_')].type=depth",
     # make eye camera vision a bit wider
     "//sensor[contains(@name, 'wide_stereo_gazebo_')]/camera/horizontal_fov=1.8",
-    # make left arm fixed
-    "//joint[contains(@name, 'pr2::l_')].type=fixed"
+    # remove unused joint
+    "//joint[contains(@name, 'pr2::l_')]=",
+    "//link[contains(@name, 'pr2::l_')]=",
+    "//joint[contains(@name, 'wheel')]=",
+    "//link[contains(@name, 'wheel')]=",
+    "//joint[contains(@name, 'caster')]=",
+    "//link[contains(@name, 'caster')]=",
+    # remove unused collision and sensor
+    # "//link[contains(@name, 'pr2::l_')]/collision=",
+    # "//sensor[contains(@name, 'wide')]=",
 ]
 
 

--- a/python/social_bot/models/pr2_noplugin/model.sdf
+++ b/python/social_bot/models/pr2_noplugin/model.sdf
@@ -5,7 +5,7 @@
     <link name="base_footprint">
       <self_collide>0</self_collide>
       <inertial>
-        <mass>118.001000</mass>
+        <mass>50.0</mass>
         <pose>-0.062421 0.000000 0.201365 0.000000 -0.000000 0.000000</pose>
         <inertia>
           <ixx>8.431730</ixx>
@@ -449,7 +449,7 @@
       <self_collide>0</self_collide>
       <pose>-0.050000 0.000000 0.790675 0.000000 -0.000000 0.000000</pose>
       <inertial>
-        <mass>36.449000</mass>
+        <mass>12.0</mass>
         <pose>-0.099499 -0.000004 -0.086764 0.000000 -0.000000 0.000000</pose>
         <inertia>
           <ixx>2.792330</ixx>
@@ -712,7 +712,7 @@
       <gravity>0</gravity>
       <pose>-0.050000 0.188000 0.790675 0.000000 -0.000000 0.000000</pose>
       <inertial>
-        <mass>25.799300</mass>
+        <mass>10.0</mass>
         <pose>-0.001201 0.024513 -0.098231 0.000000 -0.000000 0.000000</pose>
         <inertia>
           <ixx>0.866179</ixx>
@@ -1028,8 +1028,8 @@
         <surface>
           <friction>
             <ode>
-              <mu>500.000000</mu>
-              <mu2>500.000000</mu2>
+              <mu>0.800000</mu>
+              <mu2>0.800000</mu2>
               <slip1>0.000000</slip1>
               <slip2>0.000000</slip2>
             </ode>
@@ -1058,7 +1058,7 @@
       <gravity>0</gravity>
       <pose>0.939280 0.202950 0.790675 0.000000 -0.000000 0.000000</pose>
       <inertial>
-        <mass>0.044190</mass>
+        <mass>0.15</mass>
         <pose>0.004230 0.002840 0.000000 0.000000 -0.000000 0.000000</pose>
         <inertia>
           <ixx>0.000008</ixx>
@@ -1078,8 +1078,8 @@
         <surface>
           <friction>
             <ode>
-              <mu>500.000000</mu>
-              <mu2>500.000000</mu2>
+              <mu>0.800000</mu>
+              <mu2>0.800000</mu2>
               <slip1>0.000000</slip1>
               <slip2>0.000000</slip2>
             </ode>
@@ -1115,7 +1115,7 @@
       <gravity>0</gravity>
       <pose>0.939280 0.188000 0.790675 0.000000 -0.000000 0.000000</pose>
       <inertial>
-        <mass>0.010000</mass>
+        <mass>0.15</mass>
         <inertia>
           <ixx>0.001000</ixx>
           <ixy>0.000000</ixy>
@@ -1132,7 +1132,7 @@
       <gravity>0</gravity>
       <pose>0.939280 0.188000 0.790675 0.000000 -0.000000 0.000000</pose>
       <inertial>
-        <mass>0.010000</mass>
+        <mass>0.15</mass>
         <inertia>
           <ixx>0.000100</ixx>
           <ixy>0.000000</ixy>
@@ -1170,8 +1170,8 @@
         <surface>
           <friction>
             <ode>
-              <mu>500.000000</mu>
-              <mu2>500.000000</mu2>
+              <mu>0.800000</mu>
+              <mu2>0.800000</mu2>
               <slip1>0.000000</slip1>
               <slip2>0.000000</slip2>
             </ode>
@@ -1201,7 +1201,7 @@
       <gravity>0</gravity>
       <pose>0.939280 0.173050 0.790675 0.000000 -0.000000 0.000000</pose>
       <inertial>
-        <mass>0.044190</mass>
+        <mass>0.15</mass>
         <pose>0.004230 -0.002840 0.000000 0.000000 -0.000000 0.000000</pose>
         <inertia>
           <ixx>0.000008</ixx>
@@ -1222,8 +1222,8 @@
         <surface>
           <friction>
             <ode>
-              <mu>500.000000</mu>
-              <mu2>500.000000</mu2>
+              <mu>0.800000</mu>
+              <mu2>0.800000</mu2>
               <slip1>0.000000</slip1>
               <slip2>0.000000</slip2>
             </ode>
@@ -1309,7 +1309,7 @@
       <gravity>0</gravity>
       <pose>-0.050000 -0.188000 0.790675 0.000000 -0.000000 0.000000</pose>
       <inertial>
-        <mass>25.799300</mass>
+        <mass>10.0</mass>
         <pose>-0.001201 0.024513 -0.098231 0.000000 -0.000000 0.000000</pose>
         <inertia>
           <ixx>0.866179</ixx>
@@ -1661,8 +1661,8 @@
         <surface>
           <friction>
             <ode>
-              <mu>500.000000</mu>
-              <mu2>500.000000</mu2>
+              <mu>0.800000</mu>
+              <mu2>0.800000</mu2>
               <slip1>0.000000</slip1>
               <slip2>0.000000</slip2>
             </ode>
@@ -1691,7 +1691,7 @@
       <gravity>0</gravity>
       <pose>0.939280 -0.173050 0.790675 0.000000 -0.000000 0.000000</pose>
       <inertial>
-        <mass>0.044190</mass>
+        <mass>0.15</mass>
         <pose>0.004230 0.002840 0.000000 0.000000 -0.000000 0.000000</pose>
         <inertia>
           <ixx>0.000008</ixx>
@@ -1711,8 +1711,8 @@
         <surface>
           <friction>
             <ode>
-              <mu>500.000000</mu>
-              <mu2>500.000000</mu2>
+              <mu>0.800000</mu>
+              <mu2>0.800000</mu2>
               <slip1>0.000000</slip1>
               <slip2>0.000000</slip2>
             </ode>
@@ -1749,7 +1749,7 @@
       <gravity>0</gravity>
       <pose>0.939280 -0.188000 0.790675 0.000000 -0.000000 0.000000</pose>
       <inertial>
-        <mass>0.010000</mass>
+        <mass>0.15</mass>
         <inertia>
           <ixx>0.001000</ixx>
           <ixy>0.000000</ixy>
@@ -1766,7 +1766,7 @@
       <gravity>0</gravity>
       <pose>0.939280 -0.188000 0.790675 0.000000 -0.000000 0.000000</pose>
       <inertial>
-        <mass>0.010000</mass>
+        <mass>0.15</mass>
         <inertia>
           <ixx>0.000100</ixx>
           <ixy>0.000000</ixy>
@@ -1804,8 +1804,8 @@
         <surface>
           <friction>
             <ode>
-              <mu>500.000000</mu>
-              <mu2>500.000000</mu2>
+              <mu>0.800000</mu>
+              <mu2>0.800000</mu2>
               <slip1>0.000000</slip1>
               <slip2>0.000000</slip2>
             </ode>
@@ -1835,7 +1835,7 @@
       <gravity>0</gravity>
       <pose>0.939280 -0.202950 0.790675 0.000000 -0.000000 0.000000</pose>
       <inertial>
-        <mass>0.044190</mass>
+        <mass>0.15</mass>
         <pose>0.004230 -0.002840 0.000000 0.000000 -0.000000 0.000000</pose>
         <inertia>
           <ixx>0.000008</ixx>
@@ -1856,8 +1856,8 @@
         <surface>
           <friction>
             <ode>
-              <mu>500.000000</mu>
-              <mu2>500.000000</mu2>
+              <mu>0.800000</mu>
+              <mu2>0.800000</mu2>
               <slip1>0.000000</slip1>
               <slip2>0.000000</slip2>
             </ode>

--- a/python/social_bot/worlds/grocery_ground.world
+++ b/python/social_bot/worlds/grocery_ground.world
@@ -6,6 +6,9 @@
 <sdf version="1.5">
   <world name="default">
     <physics type="ode">
+      <!-- For the parameters of physics please refer to:
+        http://gazebosim.org/tutorials?tut=physics_params and
+        http://ode.org/ode-latest-userguide.html#sec_3_7_0  -->
       <max_step_size>0.001</max_step_size>
       <real_time_factor>1</real_time_factor>
       <real_time_update_rate>0</real_time_update_rate>

--- a/python/social_bot/worlds/grocery_ground.world
+++ b/python/social_bot/worlds/grocery_ground.world
@@ -9,11 +9,18 @@
       <max_step_size>0.001</max_step_size>
       <real_time_factor>1</real_time_factor>
       <real_time_update_rate>0</real_time_update_rate>
+      <max_contacts>20</max_contacts>
       <ode>
-        <solver>quick</solver>
+        <solver>
+          <type>quick</type>
+          <iters>50</iters>
+          <sor>1.3</sor>
+        </solver>
         <constraints>
           <contact_max_correcting_vel>1</contact_max_correcting_vel>
-          <contact_surface_layer>0.001</contact_surface_layer>
+          <contact_surface_layer>0.002</contact_surface_layer>
+          <cfm>0.0001</cfm>
+          <erp>0.3</erp>
         </constraints>
       </ode>
     </physics>

--- a/python/social_bot/worlds/pr2.world
+++ b/python/social_bot/worlds/pr2.world
@@ -40,12 +40,15 @@
           <surface>
             <friction>
               <ode>
-                <mu>50.0</mu>
-                <mu2>50.0</mu2>
+                <mu>1.0</mu>
+                <mu2>1.0</mu2>
               </ode>
             </friction>
           </surface>
         </collision>
+        <inertial>
+          <mass>0.15</mass>
+        </inertial>
         <visual name="visual">
           <material>
             <ambient> 0.5 0 0 1.0 </ambient>


### PR DESCRIPTION
Changes:
1. model and world file optimization: lower but reasonable mass ratio and \mu in model file, add ode simulator parameters for stability

2. remove unused joints and collisions of PR2, rather than set them to fixed. this speedup the simulating speed about 2.5x

3. add sac_pr2.gin, did a simple grid search to find better parameters. 

![image](https://user-images.githubusercontent.com/6635652/66748224-33fba100-eeb9-11e9-8f29-200400dafc8f.png)

commit 5d22142 is the orange one, reaches 750(previous PPO best performance) in 3 million env steps 