### PR TITLE
Pr discourage hitting distractions

### DIFF
--- a/python/social_bot/teacher_tasks.py
+++ b/python/social_bot/teacher_tasks.py
@@ -65,7 +65,8 @@ class GoalTask(teacher.Task):
                 it's considered a failure and is given reward -1
             distraction_penalty_distance_thresh (float): if positive, penalize agent getting too close
                 to distraction objects (objects that are not the goal itself)
-            distraction_penalty (float): how much to penalize getting too close to distraction objects
+            distraction_penalty (float): positive float of how much to penalize getting too close to
+                distraction objects
             sparse_reward (bool): if true, the reward is -1/0/1, otherwise the 0 case will be replaced
                 with normalized distance the agent get closer to goal.
             random_range (float): the goal's random position range
@@ -163,7 +164,7 @@ class GoalTask(teacher.Task):
 
             if dist < self._success_distance_thresh and dot > 0.707:
                 # within 45 degrees of the agent direction
-                reward = 1.0 + distraction_penalty
+                reward = 1.0 - distraction_penalty
                 self._push_reward_queue(reward)
                 logging.debug("loc: " + str(loc) + " goal: " + str(goal_loc) +
                               "dist: " + str(dist))
@@ -172,7 +173,7 @@ class GoalTask(teacher.Task):
                 steps_since_last_reward = 0
                 self._move_goal(goal, loc)
             elif dist > self._initial_dist + self._fail_distance_thresh:
-                reward = -1.0 + distraction_penalty
+                reward = -1.0 - distraction_penalty
                 self._push_reward_queue(0)
                 logging.debug("loc: " + str(loc) + " goal: " + str(goal_loc) +
                               "dist: " + str(dist))
@@ -182,7 +183,7 @@ class GoalTask(teacher.Task):
                     reward = 0
                 else:
                     reward = (self._prev_dist - dist) / self._initial_dist
-                reward=reward + distraction_penalty
+                reward=reward - distraction_penalty
                 self._push_reward_queue(reward)
                 self._prev_dist = dist
                 agent_sentence = yield TeacherAction(

--- a/python/social_bot/teacher_tasks.py
+++ b/python/social_bot/teacher_tasks.py
@@ -47,7 +47,7 @@ class GoalTask(teacher.Task):
                  success_distance_thresh=0.5,
                  fail_distance_thresh=0.5,
                  distraction_penalty_distance_thresh=0,
-                 distraction_penalty=0,
+                 distraction_penalty=0.5,
                  sparse_reward=True,
                  random_range=2.0,
                  use_curriculum_training=False,
@@ -333,7 +333,7 @@ class GroceryGroundGoalTask(GoalTask):
             random_id = random.randrange(len(self._goals))
             self.set_goal_name(self._goals[random_id])
         yield from GoalTask.run(self, agent, world,
-            distractions=self._objects_in_world + self._objects_to_insert)
+            distractions=self._objects_to_insert)
 
     def _insert_objects(self, object_list):
         obj_num = len(object_list)

--- a/python/social_bot/teacher_tasks.py
+++ b/python/social_bot/teacher_tasks.py
@@ -32,7 +32,7 @@ import social_bot.pygazebo as gazebo
 
 from absl import logging
 
-
+@gin.configurable
 class GoalTask(teacher.Task):
     """
     A simple teacher task to find a goal.
@@ -46,6 +46,8 @@ class GoalTask(teacher.Task):
                  goal_name="goal",
                  success_distance_thresh=0.5,
                  fail_distance_thresh=0.5,
+                 distraction_penalty_distance_thresh=0,
+                 distraction_penalty=0,
                  sparse_reward=True,
                  random_range=2.0,
                  use_curriculum_training=False,
@@ -61,6 +63,9 @@ class GoalTask(teacher.Task):
             success_distance_thresh (float): the goal is reached if it's within this distance to the agent
             fail_distance_thresh (float): if the agent moves away from the goal more than this distance,
                 it's considered a failure and is given reward -1
+            distraction_penalty_distance_thresh (float): if positive, penalize agent getting too close
+                to distraction objects (objects that are not the goal itself)
+            distraction_penalty (float): how much to penalize getting too close to distraction objects
             sparse_reward (bool): if true, the reward is -1/0/1, otherwise the 0 case will be replaced
                 with normalized distance the agent get closer to goal.
             random_range (float): the goal's random position range
@@ -78,6 +83,8 @@ class GoalTask(teacher.Task):
         self._goal_name = goal_name
         self._success_distance_thresh = success_distance_thresh
         self._fail_distance_thresh = fail_distance_thresh
+        self._distraction_penalty_distance_thresh = distraction_penalty_distance_thresh
+        self._distraction_penalty = distraction_penalty
         self._max_steps = max_steps
         self._sparse_reward = sparse_reward
         self._use_curriculum_training = use_curriculum_training
@@ -117,7 +124,7 @@ class GoalTask(teacher.Task):
     def get_random_range(self):
         return self._random_range
 
-    def run(self, agent, world):
+    def run(self, agent, world, distractions=None):
         """
         Start a teaching episode for this task.
         Args:
@@ -142,25 +149,40 @@ class GoalTask(teacher.Task):
             dir = np.array([math.cos(dir[2]), math.sin(dir[2])])
             goal_dir = (goal_loc[0:2] - loc[0:2]) / dist
             dot = sum(dir * goal_dir)
+
+            distraction_penalty = 0
+            if self._distraction_penalty_distance_thresh > 0 and distractions:
+                for obj_name in distractions:
+                    obj = world.get_agent(obj_name)
+                    if obj:
+                        obj_loc, obj_dir = obj.get_pose()
+                        obj_loc = np.array(obj_loc)
+                        distraction_dist = np.linalg.norm(loc - obj_loc)
+                        if distraction_dist < self._distraction_penalty_distance_thresh:
+                            distraction_penalty += self._distraction_penalty
+
             if dist < self._success_distance_thresh and dot > 0.707:
                 # within 45 degrees of the agent direction
-                self._push_reward_queue(1)
+                reward = 1.0 + distraction_penalty
+                self._push_reward_queue(reward)
                 logging.debug("loc: " + str(loc) + " goal: " + str(goal_loc) +
                               "dist: " + str(dist))
                 agent_sentence = yield TeacherAction(
-                    reward=1.0, sentence="well done", done=False)
+                    reward=reward, sentence="well done", done=False)
                 steps_since_last_reward = 0
                 self._move_goal(goal, loc)
             elif dist > self._initial_dist + self._fail_distance_thresh:
+                reward = -1.0 + distraction_penalty
                 self._push_reward_queue(0)
                 logging.debug("loc: " + str(loc) + " goal: " + str(goal_loc) +
                               "dist: " + str(dist))
-                yield TeacherAction(reward=-1.0, sentence="failed", done=True)
+                yield TeacherAction(reward=reward, sentence="failed", done=True)
             else:
                 if self._sparse_reward:
                     reward = 0
                 else:
                     reward = (self._prev_dist - dist) / self._initial_dist
+                reward=reward + distraction_penalty
                 self._push_reward_queue(reward)
                 self._prev_dist = dist
                 agent_sentence = yield TeacherAction(
@@ -285,8 +307,9 @@ class GroceryGroundGoalTask(GoalTask):
         self._goals = self._objects_to_insert
         if self._random_goal:
             self._goals = self._goal_name.split(',')
-        logging.info("goal_name %s, random_goal %d, fail_distance_thresh %f,",
-                     self._goal_name, self._random_goal, fail_distance_thresh)
+        logging.info("goal_name %s, random_goal %d, random_range %d," +
+            " fail_distance_thresh %f,", self._goal_name, self._random_goal,
+            self._random_range, fail_distance_thresh)
         if GoalTask.should_use_curriculum_training(self):
             logging.info("start_range %f, reward_thresh_to_increase_range %f",
                          self._start_range,
@@ -294,7 +317,7 @@ class GroceryGroundGoalTask(GoalTask):
         self._pos_list = list(itertools.product(range(-5, 5), range(-5, 5)))
         self._pos_list.remove((0, 0))
         self.reward_weight = reward_weight
-        self.task_vocab = self.task_vocab + self._objects_in_world + self._objects_to_insert
+        self.task_vocab += self._objects_in_world + self._objects_to_insert
 
     def setup(self, world, agent_name):
         """
@@ -308,7 +331,8 @@ class GroceryGroundGoalTask(GoalTask):
         if self._random_goal:
             random_id = random.randrange(len(self._goals))
             self.set_goal_name(self._goals[random_id])
-        yield from GoalTask.run(self, agent, world)
+        yield from GoalTask.run(self, agent, world,
+            distractions=self._objects_in_world + self._objects_to_insert)
 
     def _insert_objects(self, object_list):
         obj_num = len(object_list)


### PR DESCRIPTION
Hey Jiangtao and Wei,

I'm trying to discourage the bot from bumping into random objects when chasing after the goal target.

This change reduces reward by a configurable value (distraction_penalty) every time the robot bumps into an object (gets very close to an object).  It also decreases the reward_q average, and prevents the curriculum from advancing if robot keeps bumping into distractions.

Let me know what do you think about this change.  I started a training session with penalty distance threshold = 0.25 (compared to success distance of 0.5) and penalty = 0.5 (compared to reward of reaching goal 1.0).

Thanks,
Le