### PR TITLE
Fix the ball dropping issue for play_ground at the beginning of each …

### DIFF
--- a/python/social_bot/envs/simple_navigation.py
+++ b/python/social_bot/envs/simple_navigation.py
@@ -146,7 +146,7 @@ class SimpleNavigation(GazeboEnvBase):
         """
         Args:
             action (dict|int): If with_language, action is a dictionary with key "control" and "sentence".
-                    action['control'] is a vector whose dimention is
+                    action['control'] is a vector whose dimension is
                     len(_joint_names). action['sentence'] is a sentence sequence.
                     If not with_language, it is an int for the action id.
         Returns:

--- a/python/social_bot/models/ball/model.sdf
+++ b/python/social_bot/models/ball/model.sdf
@@ -1,8 +1,9 @@
 <?xml version="1.0" ?>
 <sdf version="1.5">
   <model name="ball">
-    <pose>0 0 0.127 0 0 0</pose>
+    <pose>0 0 0 0 0 0</pose>
     <link name="link">
+      <pose>0 0 0.127 0 0 0</pose>
       <inertial>
         <mass>0.15</mass>
         <inertia>


### PR DESCRIPTION
…episode.

Previously, the ball (goal) always drops from above at the beginning of each episode.
It turns out this is caused by the bouncing due to incorrect pose.