### PR TITLE
Add pr2 unit test and fix pr2gripping task

### DIFF
--- a/python/social_bot/envs/pr2.py
+++ b/python/social_bot/envs/pr2.py
@@ -18,16 +18,16 @@ PR2_WORLD_SETTING = [
     "//camera//height=256",
     "//camera//format=L8",
     # make head fixed
-    "//joint[contains(@name, 'pr2::head_')].type=fixed",
+    "//joint[contains(@name, 'pr2_noplugin::head_')].type=fixed",
     # make eye camera sensor focus on the table
-    "//link[@name='pr2::head_tilt_link']/pose=0.033267 -0.003973 1.1676 0.000174 1.0 -0.013584",
+    "//link[@name='pr2_noplugin::head_tilt_link']/pose=0.033267 -0.003973 1.1676 0.000174 1.0 -0.013584",
     # using depth camera
     # "//sensor[contains(@name, 'wide_stereo_gazebo_')].type=depth",
     # make eye camera vision a bit wider
     "//sensor[contains(@name, 'wide_stereo_gazebo_')]/camera/horizontal_fov=1.8",
     # remove unused joint
-    "//joint[contains(@name, 'pr2::l_')]=",
-    "//link[contains(@name, 'pr2::l_')]=",
+    "//joint[contains(@name, 'pr2_noplugin::l_')]=",
+    "//link[contains(@name, 'pr2_noplugin::l_')]=",
     "//joint[contains(@name, 'wheel')]=",
     "//link[contains(@name, 'wheel')]=",
     "//joint[contains(@name, 'caster')]=",
@@ -38,7 +38,7 @@ PR2_WORLD_SETTING = [
     "//sensor[@name='r_forearm_cam_sensor']=",
 
     # remove unused collision and sensor
-    # "//link[contains(@name, 'pr2::l_')]/collision=",
+    # "//link[contains(@name, 'pr2_noplugin::l_')]/collision=",
     # "//sensor[contains(@name, 'wide')]=",
 ]
 
@@ -143,7 +143,7 @@ class Pr2Gripper(GazeboEnvBase):
 
         self._r_arm_joints = list(
             filter(
-                lambda s: s.find('pr2::r_') != -1 and s.split("::")[-1] not in unused_joints,
+                lambda s: s.find('pr2_noplugin::r_') != -1 and s.split("::")[-1] not in unused_joints,
                 self._all_joints))
         logging.debug(
             "joints in the right arm to control: %s" % self._r_arm_joints)
@@ -234,9 +234,9 @@ class Pr2Gripper(GazeboEnvBase):
             "beer::link::box_collision")
         self._goal_pose = self._goal.get_pose()
         self._l_finger_pose = self._agent.get_link_pose(
-            "pr2::pr2::r_gripper_l_finger_tip_link")
+            "pr2::pr2_noplugin::r_gripper_l_finger_tip_link")
         self._r_finger_pose = self._agent.get_link_pose(
-            "pr2::pr2::r_gripper_r_finger_tip_link")
+            "pr2::pr2_noplugin::r_gripper_r_finger_tip_link")
 
         joint_states = [
             self._agent.get_joint_state(joint) for joint in self._r_arm_joints
@@ -268,10 +268,10 @@ class Pr2Gripper(GazeboEnvBase):
                 0)
 
             img = get_camera_observation(
-                "default::pr2::pr2::head_tilt_link::wide_stereo_gazebo_l_stereo_camera_sensor"
+                "default::pr2::pr2_noplugin::head_tilt_link::wide_stereo_gazebo_l_stereo_camera_sensor"
             )
             img2 = get_camera_observation(
-                "default::pr2::pr2::head_tilt_link::wide_stereo_gazebo_r_stereo_camera_sensor"
+                "default::pr2::pr2_noplugin::head_tilt_link::wide_stereo_gazebo_r_stereo_camera_sensor"
             )
             obs = OrderedDict(
                 image=np.concatenate((img, img2), axis=-1), states=states)
@@ -300,7 +300,8 @@ class Pr2Gripper(GazeboEnvBase):
     # gripper_joint is 1 DOF prismatic joint, the joint state represent the
     # the parallel distance between two finger tips. see PR2 manual p18.
     def _get_gripper_pos(self):
-        state = self._agent.get_joint_state("pr2::pr2::r_gripper_joint")
+        state = self._agent.get_joint_state(
+            "pr2::pr2_noplugin::r_gripper_joint")
         return state.get_positions()[0]
 
     def step(self, actions):
@@ -383,16 +384,16 @@ class Pr2Gripper(GazeboEnvBase):
         self._prev_gripper_pos = gripper_pos
         return obs, reward, done, {}
 
-    def run(self):
+    def run(self, render=True):
         self.reset()
         reward = 0.0
         count = 0
-
         time_start = time.time()
-        while True:
+        while count <= 200:
             actions = self.action_space.sample()
             obs, r, done, _ = self.step(actions * self._gripper_reward_dir)
-            self.render('human')
+            if render:
+                self.render('human')
             count += 1
             reward += r
 

--- a/python/social_bot/envs/pr2_test.py
+++ b/python/social_bot/envs/pr2_test.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2019 Horizon Robotics. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import social_bot
+import social_bot.pygazebo as gazebo
+from absl import logging
+from pr2 import Pr2Gripper
+from pr2 import PR2_WORLD_SETTING
+
+
+class TestPr2(unittest.TestCase):
+
+    def test_pr2(self):
+        for use_internal_states_only in [True, False]:
+            env = Pr2Gripper(
+            world_config=PR2_WORLD_SETTING + [
+                "//sensor[@type='camera']<>visualize=true",
+                "//camera//format=R8G8B8",
+            ],
+            max_steps=100,
+            use_internal_states_only=use_internal_states_only)
+            
+            env.run(render=False)
+            env.close()
+            gazebo.close()
+
+
+if __name__ == '__main__':
+    logging.set_verbosity(logging.INFO)
+    unittest.main()

--- a/python/social_bot/envs/simple_navigation_test.py
+++ b/python/social_bot/envs/simple_navigation_test.py
@@ -18,6 +18,7 @@ from multiprocessing import Process, Value
 from simple_navigation import SimpleNavigationLanguage
 import random
 import os
+import social_bot.pygazebo as gazebo
 
 
 class SimpleNaviEnv(Process):
@@ -39,6 +40,8 @@ class SimpleNaviEnv(Process):
                 dict(control=control, sentence="hello"))
             if done:
                 env.reset()
+        env.close()
+        gazebo.close()
         self.ok.value = 1
 
 


### PR DESCRIPTION
Changes:
1. Fix the problem that pr2gripping fails to run due to unifying model name in PR #99 
2. Add pr2 unit test; 
3. Add "gazebo.close()" to simple navigation to avoid gazebo master URI conflicting