### PR TITLE
Update pick place task traning example

### DIFF
--- a/examples/pickplace_sac_youbot.gin
+++ b/examples/pickplace_sac_youbot.gin
@@ -21,9 +21,10 @@ PickAndPlace.reward_shaping=True
 PlayGround.action_wrapper=@YoubotActionWrapper
 
 # algorithm config
-actor/Adam.learning_rate=5e-4
-critic/Adam.learning_rate=5e-4
-alpha/Adam.learning_rate=5e-4
+actor/Adam.learning_rate=1e-3
+critic/Adam.learning_rate=1e-3
+alpha/Adam.learning_rate=1e-3
+OneStepTDLoss.gamma=0.98
 
 # training config
 TrainerConfig.initial_collect_steps=2000

--- a/python/social_bot/tasks.py
+++ b/python/social_bot/tasks.py
@@ -982,12 +982,12 @@ class PickAndPlace(Task):
                 np.array(obj_pos) - np.array(finger_pos))
             obj_lifted = obj_height / self._obj_init_height - 1.0
             gripping_feature = 0.25 * l_contact + 0.25 * r_contact + min(
-                obj_lifted, 1.0)  # encourge to lift the object by obj_height
-            gripping = (gripping_feature >= 0.999999)
+                obj_lifted, 0.5)  # encourge to lift the object by obj_height
+            gripping = (gripping_feature > 0.99)
             # success condition, minus an offset of object height on z-axis
             if gripping and obj_dist_xy < self._success_distance_thresh and dist_z - self._obj_init_height < self._success_distance_thresh:
                 logging.debug("object has been successfuly placed")
-                reward = 100.0 if self._reward_shaping else 1.0
+                reward = 200.0 if self._reward_shaping else 1.0
                 agent_sentence = yield TeacherAction(
                     reward=reward, sentence="well done", done=True)
             else:


### PR DESCRIPTION
I found the episode length begin to increase at the late training progress, which means it takes longer to successfully place object to the goal.

The reason might be the one discussed in https://github.com/HorizonRobotics/SocialRobot/pull/113#discussion_r354649180

The reward shaping before: in the first stage (gripper get closer to the object) max reward is 1; and the second stage(place object to goal position) max reward is 2; and finally given a 100 when success.

Final reward is 100 and the training example's discount factor gamma is 0.99, the agent will find play around near the goal has higher discounted return:
`100 < 2 + 100*0.99 < 2 + 2*0.99 + 100*0.99^2` ...

So I've changed final reward to 200 and gamma to 0.98, to make success immediately is higher than play around the goal's position (200 > 2 + 200*0.98).  The result is much better, can successfully place the object to goal in 40 steps on average.

![image](https://user-images.githubusercontent.com/6635652/71235031-e591d500-2335-11ea-971b-24096847167a.png)

Other changes include using the action wrapper which remove 2 redundant dimensions and increase learning rate from 5e-4 to 1e-3:

- Blue is the original curve of PR 113;
- Green is PR113 with action wrapper, note that random range has also been increased a little bit since https://github.com/HorizonRobotics/SocialRobot/pull/116#discussion_r358712436;
- Orange is PR113 with action wrapper and 1e-3 learning rate;
- Red is current one, with action wrapper, higher LR and new gamma.