### PR TITLE
add 'success' field to TeacherAction

### DIFF
--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.6
+    - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: 3.7
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -45,4 +45,4 @@ jobs:
     - name: Test with pytest
       run: |
         cd ./python/social_bot/envs
-        GAZEBO_MODEL_PATH=../models PYTHONPATH=../:$PYTHONPATH xvfb-run python3 -m unittest discover -p "*_test.py" -v
+        GAZEBO_MODEL_PATH=../models xvfb-run python3 -m unittest discover -p "*_test.py" -v

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -45,4 +45,4 @@ jobs:
     - name: Test with pytest
       run: |
         cd ./python/social_bot/envs
-        GAZEBO_MODEL_PATH=../models xvfb-run python3 -m unittest discover -p "*_test.py" -v
+        GAZEBO_MODEL_PATH=../models PYTHONPATH=../:$PYTHONPATH xvfb-run python3 -m unittest discover -p "*_test.py" -v

--- a/python/social_bot/envs/play_ground.py
+++ b/python/social_bot/envs/play_ground.py
@@ -238,7 +238,7 @@ class PlayGround(GazeboEnvBase):
         if teacher_action.done:
             logging.debug("episode ends at cum reward:" +
                           str(self._cum_reward))
-        return obs, reward, teacher_action.done, {}
+        return obs, reward, teacher_action.done, {"is_success": teacher_action.success}
 
     def get_step_time(self):
         """

--- a/python/social_bot/tasks.py
+++ b/python/social_bot/tasks.py
@@ -89,9 +89,9 @@ class Task(object):
         The extra infomation needed by the task if sparse states are used.
 
         This can be overridden by the sub task. Note that this is only for the
-        case "Agent._use_image_observation" is False. For image case, the 
+        case "Agent._use_image_observation" is False. For image case, the
         image form camera of agent is used. For case of image with internal
-        states, Agent.get_internal_states() is used, which only returns 
+        states, Agent.get_internal_states() is used, which only returns
         self joint positions and velocities.
 
         Args:
@@ -103,7 +103,7 @@ class Task(object):
 
     def set_agent(self, agent):
         """ Set the agent of task.
-        
+
         The agent can be overridden by this function. This might be useful when multi
         agents share the same task or embodied teacher.
         Args:
@@ -388,7 +388,10 @@ class GoalTask(Task):
                 self._push_reward_queue(max(reward, 0))
                 logging.debug("yielding reward: " + str(reward))
                 agent_sentence = yield TeacherAction(
-                    reward=reward, sentence="well done", done=False)
+                    reward=reward, sentence="well done",
+                    done=not (self._move_goal_during_episode
+                              or self._switch_goal_within_episode),
+                    success=True)
                 steps_since_last_reward = 0
                 if self._switch_goal_within_episode:
                     self.pick_goal()

--- a/python/social_bot/teacher.py
+++ b/python/social_bot/teacher.py
@@ -36,15 +36,18 @@ class DiscreteSequence(gym.Space):
 
 
 class TeacherAction(object):
-    def __init__(self, reward=0.0, sentence="", done=False, is_idle=False):
+    def __init__(self, reward=0.0, sentence="", done=False, is_idle=False,
+                 success=False):
         """
         Args:
             done: end of an episode if true
+            success: if the episode is successful or not
         """
         self.reward = reward
         self.sentence = sentence
         self.done = done
         self.is_idle = is_idle
+        self.success = success
 
 
 class TaskGroup(object):
@@ -330,11 +333,14 @@ class Teacher(object):
             final_reward = 0.
             done = False
             active_group_id = -1
+            success = False
             # run all groups in parallel
             for i, g in enumerate(self._task_groups):
                 teacher_action = g.teach(agent_sentence)
                 if teacher_action.done:
                     done = True
+                if teacher_action.success:
+                    success = True
                 weight = g.get_current_reward_weight()
                 final_reward += weight * teacher_action.reward
                 if not final_sentence:
@@ -343,5 +349,6 @@ class Teacher(object):
             if active_group_id != -1:
                 g = self._task_groups.pop(active_group_id)
                 self._task_groups.insert(0, g)
-            return_action = TeacherAction(final_reward, final_sentence, done)
+            return_action = TeacherAction(final_reward, final_sentence, done,
+                                          success=success)
         return return_action


### PR DESCRIPTION
Currently only use this flag in PlayGround with GoalTask/PickAndPlace/KickBallTask. Other tasks will get a default value of False, which is compatible since we never had this info before.

Also add an option "sparse_reward" for KickBallTask.