### PR TITLE
make kickball task more realistic

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ We provide OpenAI gym interfaces to easily apply different RL algorithms into th
 Some environments support the teacher-student learning procedure, in which the task is defined by the teacher, and an interaction with the teacher via a sentence is performed during each environment step. You could enable the procedure by using the environment whose name contains "language" or through gin configuration.
 
 ### [Play Ground](python/social_bot/envs/play_ground.py)
-A flexiable environment in which worldfile, tasks and agent are all configurable through gin file. The default configuration for play ground is goal task and pioneer agent. 
+A flexiable environment in which worldfile, tasks and agent are all configurable through gin file. The default configuration for play ground is goal task and pioneer agent.
 You can choose the agent type in the environment by setting the paramenter "agent_type". We support pioneer2dx, pr2, turtlebot, kuka youbot, kuka LWR4 and icub for now. [ICub](http://www.icub.org) is an humanoid robot meant for more complex tasks in the future. You could also choose icub_with_hands, which is a more advanced version of icub equipped with 2 cameras and dexterous hands. The following are images of these 5 robots:
 
 <img src="media/pioneer.jpg" width="160" height="240" alt="pioneer"/> <img src="media/pr2.jpg" width="160" height="240" alt="pr2"/> <img src="media/turtlebot.jpg" width="160" height="240" alt="turtlebot"/> <img src="media/icub.jpg" width="160" height="240" alt="icub"/> <img src="media/youbot.jpg" width="160" height="240" alt="youbot"/>
@@ -75,10 +75,10 @@ Your can configure the type of observation using gin: with_language or not, use_
     image from the camera of agent,
     image with internal states,
     image with language sentence,
-    image with both internal states and language sentence. 
+    image with both internal states and language sentence.
 By default low-dimensional full states is used.
 
-The action specification is defined in the joint list of file [agent_cfg.json](python/social_bot/models/agent_cfg.json). 
+The action specification is defined in the joint list of file [agent_cfg.json](python/social_bot/models/agent_cfg.json).
 
 Tasks are in file [tasks.py](python/social_bot/tasks.py). To implement a new task, you should:
 1. Inherit `tasks.Task`, speficy the compatible agent types in "Task.compatible_agents".
@@ -92,10 +92,10 @@ The tasks we have for now are listed as below:
 
     <img src="media/pioneer.gif" width="320" height="240" alt="pioneer"/> <img src="media/play_ground_icub.gif" width="360" height="240" alt="icub"/>
 
-* [Kicking-ball task](python/social_bot/tasks.py): A task to kick a ball into the goal. Simple reward shaping is used to guide the agent to run to the ball first.
+* [Kicking-ball task](python/social_bot/tasks.py): A task to kick a ball into the goal. Optional reward shaping can be used to guide the agent to run to the ball first.
 
     <img src="media/play_ground_ball.gif" width="320" height="240" alt="ball"/>
-    
+
 * [Reaching3D task](python/social_bot/tasks.py): A task to reach a 3D position with the end effector of a robot arm. This task is only compatible with Agent kuka_lwr_4plus. An optional distance based reward shaping can be used.
 
     <img src="media/reaching.gif" width="320" height="240" alt="reaching"/>
@@ -153,9 +153,9 @@ Try this for a test:
 ```bash
 cd REPO_ROOT/python/social_bot/
 python keybo_control.py
-``` 
+```
 Move the agent around by key "W, A, S, D", open or close gripper by key "E", and move the robot arm (if there is, such as agent youbot) by mouse for lef-right, forward-backward direction, and key "R, F" for up-down.
-Note that some tricks are used to make the operating more friendly. So you are not controlling the raw joints as the algorthim. 
+Note that some tricks are used to make the operating more friendly. So you are not controlling the raw joints as the algorthim.
 It's not so easy, for some task you may need some trials to complete it. An example:
 
 <img src="media/stack.gif" width="450" height="200" alt="stack"/>

--- a/python/social_bot/tasks.py
+++ b/python/social_bot/tasks.py
@@ -812,13 +812,13 @@ class ICubAuxiliaryTask(Task):
 @gin.configurable
 class KickingBallTask(Task):
     """
-    A simple task to kick a ball so that it rolls into the gate. An
+    A simple task to kick a ball so that it rolls into the goal. An
     optional reward shaping can be used to guide the agent run to the ball first:
-        Agent will receive 100 when succefully kick the ball into the gate.
+        Agent will receive 100 when succefully kick the ball into the goal.
         Agent will receive the speed of getting closer to the ball before touching the
             ball within 45 degrees of agent direction. The reward is trunked within
             parameter target_speed.
-        Agent will receive negative normalized distance from ball to gate center
+        Agent will receive negative normalized distance from ball to goal center
             after touching the ball within the direction. An offset of
             "target_speed + 1" is included since touching the ball must be better
             than not touching.
@@ -829,7 +829,7 @@ class KickingBallTask(Task):
     def __init__(self,
                  env,
                  max_steps,
-                 gate_distance=5.0,
+                 goal_distance=5.0,
                  random_range=4.0,
                  target_speed=2.0,
                  reward_weight=1.0,
@@ -839,7 +839,7 @@ class KickingBallTask(Task):
             env (gym.Env): an instance of Environment
             max_steps (int): episode will end if the task is not achieved in so
                 many steps
-            gate_distance (float): the distance from the gate to the ball on
+            goal_distance (float): the distance from the goal to the ball on
                 average. A smaller distance makes the kicking task easier.
             random_range (float): the ball's random position range
             target_speed (float): the target speed runing to the ball. The agent will receive no more
@@ -852,29 +852,29 @@ class KickingBallTask(Task):
         self._random_range = random_range
         self._target_speed = target_speed
         self._sparse_reward = sparse_reward
-        self._gate_distance = gate_distance
+        self._goal_distance = goal_distance
         # By looking up the 'robocup_3Dsim_goal' model file:
-        self._gate_width = 2.1
-        self._gate_post_radius = 0.05
+        self._goal_width = 2.1
+        self._goal_post_radius = 0.05
         self._env.insert_model(
             model="robocup_3Dsim_goal",
-            name="gate",
-            pose="-%s 0 0 0 -0 3.14159265" % gate_distance)
+            name="goal",
+            pose="-%s 0 0 0 -0 3.14159265" % goal_distance)
         self._env.insert_model(model="ball", pose="1.50 1.5 0.2 0 -0 0")
 
     def run(self):
         """ Start a teaching episode for this task. """
         agent_sentence = yield
-        gate = self._world.get_model("gate")
+        goal = self._world.get_model("goal")
         ball = self._world.get_model("ball")
-        gate_loc, dir = gate.get_pose()
+        goal_loc, dir = goal.get_pose()
         self._move_ball(ball)
         agent_loc, dir = self._agent.get_pose()
         ball_loc, _ = ball.get_pose()
         prev_dist = np.linalg.norm(
             np.array(ball_loc)[:2] - np.array(agent_loc)[:2])
-        init_gate_dist = np.linalg.norm(
-            np.array(ball_loc)[:2] - np.array(gate_loc)[:2])
+        init_goal_dist = np.linalg.norm(
+            np.array(ball_loc)[:2] - np.array(goal_loc)[:2])
         steps = 0
         hitted_ball = False
         while steps < self._max_steps:
@@ -895,19 +895,19 @@ class KickingBallTask(Task):
                 prev_dist = dist
                 if dist < 0.3:
                     dir = np.array([math.cos(dir[2]), math.sin(dir[2])])
-                    gate_dir = (np.array(ball_loc[0:2]) - np.array(
+                    ball_dir = (np.array(ball_loc[0:2]) - np.array(
                         agent_loc[0:2])) / dist
-                    dot = sum(dir * gate_dir)
+                    dot = sum(dir * ball_dir)
                     if dot > 0.707:
                         # within 45 degrees of the agent direction
                         hitted_ball = True
                 agent_sentence = yield TeacherAction(reward=progress_reward)
             else:
-                gate_loc, _ = gate.get_pose()
+                goal_loc, _ = goal.get_pose()
                 ball_loc, _ = ball.get_pose()
                 dist = np.linalg.norm(
-                    np.array(ball_loc)[:2] - np.array(gate_loc)[:2])
-                if self._in_the_gate(ball_loc):
+                    np.array(ball_loc)[:2] - np.array(goal_loc)[:2])
+                if self._in_the_goal(ball_loc):
                     if self._sparse_reward:
                         reward = 1.
                     else:
@@ -919,7 +919,7 @@ class KickingBallTask(Task):
                     if self._sparse_reward:
                         reward = 0.
                     else:
-                        reward = self._target_speed + 3 - dist / init_gate_dist
+                        reward = self._target_speed + 3 - dist / init_goal_dist
                     agent_sentence = yield TeacherAction(
                         reward=reward)
         yield TeacherAction(reward=-1.0, sentence="failed", done=True)
@@ -931,7 +931,7 @@ class KickingBallTask(Task):
         Returns:
             np.array, the observations of the task for non-image case
         """
-        obj_poses = self._get_states_of_model_list(['ball', 'gate'])
+        obj_poses = self._get_states_of_model_list(['ball', 'goal'])
         agent_pose = np.array(agent.get_pose()).flatten()
         agent_vel = np.array(agent.get_velocities()).flatten()
         joints_states = agent.get_internal_states()
@@ -939,18 +939,18 @@ class KickingBallTask(Task):
                              axis=0)
         return obs
 
-    def _in_the_gate(self, ball_loc):
-        pass_gate_line = (ball_loc[0] < -self._gate_distance)
-        half_width = self._gate_width / 2 - self._gate_post_radius # =1.0
-        within_gate = (half_width > ball_loc[1] > -half_width)
-        return (pass_gate_line and within_gate)
+    def _in_the_goal(self, ball_loc):
+        pass_goal_line = (ball_loc[0] < -self._goal_distance)
+        half_width = self._goal_width / 2 - self._goal_post_radius # =1.0
+        within_goal = (half_width > ball_loc[1] > -half_width)
+        return (pass_goal_line and within_goal)
 
     def _move_ball(self, ball):
         range = self._random_range
         while True:
             loc = (random.random() * range - range / 2,
                    random.random() * range - range / 2, 0)
-            if not self._in_the_gate(loc):
+            if not self._in_the_goal(loc):
                 break
         ball.set_pose((loc, (0, 0, 0)))
 


### PR DESCRIPTION
The current implementation treats the entire gate as a point mass and the success condition is that the distance between the ball and the gate center is smaller than a threshold. This is unrealistic because normally one would assume that as long as the ball

1) passes the gate line, and
2) is between the two gate posts

Then it's a goal. 

So this PR changes the success condition to the above. As I checked, no existing example or the readme will be affected by this PR. Note that the existing reward shaping that's based on the distance between gate center and ball can still be used as an approximation.

Compared to the existing setup: The existing setup has a default value of 0.5 for the success distance threshold. Since the gate width is 2.0 then there will be certain areas near the two posts that won't be counted as successes even if the ball actually rolls into the gate.