### PR TITLE
Upgrade gym: 0.15.3 -> 0.15.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     version='0.0.1',
     install_requires=[
         'gin-config@git+https://github.com/HorizonRobotics/gin-config.git',
-        'gym == 0.15.3', 'numpy >= 1.13.3', 'matplotlib', 'psutil',
+        'gym == 0.15.4', 'numpy >= 1.13.3', 'matplotlib', 'psutil',
         'lxml >= 3.5.0', 'Pillow', 'absl-py', 'pytest', 'PyUserInput',
         'python-xlib'
     ],


### PR DESCRIPTION
# Motivation

To make it consistent with alf as alf is using gym 0.15.4.

# Solution

Bump up the version of gym in SocialRobots as well.

# Testing

Passed CI.
